### PR TITLE
fix: add response headers and fix a null pointer exception

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/HTTPServer.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/HTTPServer.kt
@@ -68,6 +68,10 @@ internal object HTTPServer {
                 obtainProtocolData()
             }
         }
+
+//        intercept(ApplicationCallPipeline.Plugins) {
+//            call.response.headers.appendIfAbsent("Content-Type", ContentType.Application.Json.toString())
+//        }
     }
 
     private fun ApplicationEngineEnvironmentBuilder.configSSL() {

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/FriendAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/FriendAction.kt
@@ -2,6 +2,7 @@ package moe.fuqiuluo.shamrock.remote.api
 
 import com.tencent.mobileqq.profilecard.api.IProfileCardBlacklistApi
 import com.tencent.mobileqq.qroute.QRoute
+import io.ktor.http.ContentType
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Routing
@@ -17,16 +18,16 @@ import moe.fuqiuluo.shamrock.tools.getOrPost
 fun Routing.friendAction() {
     getOrPost("/get_stranger_info") {
         val uin = fetchOrThrow("user_id")
-        call.respondText(GetStrangerInfo(uin))
+        call.respondText(GetStrangerInfo(uin), ContentType.Application.Json)
     }
 
     getOrPost("/get_friend_list") {
         val refresh = fetchOrNull("refresh")?.toBooleanStrictOrNull() ?: false
-        call.respondText(GetFriendList(refresh))
+        call.respondText(GetFriendList(refresh), ContentType.Application.Json)
     }
 
     getOrPost("/is_blacklist_uin") {
         val uin = fetchOrThrow("user_id")
-        call.respondText(IsBlackListUin(uin))
+        call.respondText(IsBlackListUin(uin), ContentType.Application.Json)
     }
 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/GroupAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/GroupAction.kt
@@ -1,5 +1,6 @@
 package moe.fuqiuluo.shamrock.remote.api
 
+import io.ktor.http.ContentType
 import moe.fuqiuluo.shamrock.helper.LogicException
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
@@ -15,70 +16,70 @@ fun Routing.troopAction() {
     getOrPost("/group_touch") {
         val groupId = fetchOrThrow("group_id")
         val userId = fetchOrThrow("user_id")
-        call.respondText(GroupPoke(groupId, userId))
+        call.respondText(GroupPoke(groupId, userId), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_honor_info") {
         val groupId = fetchOrThrow("group_id")
         val refresh = fetchOrNull("refresh")?.toBooleanStrict() ?: false
-        call.respondText(GetTroopHonor(groupId, refresh))
+        call.respondText(GetTroopHonor(groupId, refresh), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_member_list") {
         val groupId = fetchOrThrow("group_id")
         val refresh = fetchOrNull("refresh")?.toBooleanStrict() ?: false
-        call.respondText(GetTroopMemberList(groupId, refresh))
+        call.respondText(GetTroopMemberList(groupId, refresh), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_member_info") {
         val groupId = fetchOrThrow("group_id")
         val userId = fetchOrThrow("user_id")
         val refresh = fetchOrNull("no_cache")?.toBooleanStrict() ?: false
-        call.respondText(GetTroopMemberInfo(groupId, userId, refresh))
+        call.respondText(GetTroopMemberInfo(groupId, userId, refresh), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_list") {
         val refresh = fetchOrNull("refresh")?.toBooleanStrict() ?: true
-        call.respondText(GetTroopList(refresh))
+        call.respondText(GetTroopList(refresh), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_info") {
         val groupId = fetchOrThrow("group_id")
         val refresh = fetchOrNull("no_cache")?.toBooleanStrict() ?: false
-        call.respondText(GetTroopInfo(groupId, refresh))
+        call.respondText(GetTroopInfo(groupId, refresh), ContentType.Application.Json)
     }
 
     getOrPost("/set_group_special_title") {
         val groupId = fetchOrThrow("group_id")
         val userId = fetchOrThrow("user_id")
         val title = fetchOrThrow("special_title")
-        call.respondText(SetGroupUnique(groupId, userId, title))
+        call.respondText(SetGroupUnique(groupId, userId, title), ContentType.Application.Json)
     }
 
     getOrPost("/set_group_name") {
         val groupId = fetchOrThrow("group_id")
         val card = fetchOrThrow("group_name")
-        call.respondText(ModifyTroopName(groupId, card))
+        call.respondText(ModifyTroopName(groupId, card), ContentType.Application.Json)
     }
 
     getOrPost("/set_group_card") {
         val groupId = fetchOrThrow("group_id")
         val userId = fetchOrThrow("user_id")
         val card = fetchOrNull("card") ?: ""
-        call.respondText(ModifyTroopMemberName(groupId, userId, card))
+        call.respondText(ModifyTroopMemberName(groupId, userId, card), ContentType.Application.Json)
     }
 
     getOrPost("/set_group_admin") {
         val groupId = fetchOrThrow("group_id") .toLong()
         val userId = fetchOrThrow("user_id") .toLong()
         val enable = fetchOrThrow("enable").toBooleanStrict()
-        call.respondText(SetGroupAdmin(groupId, userId, enable))
+        call.respondText(SetGroupAdmin(groupId, userId, enable), ContentType.Application.Json)
     }
 
     getOrPost("/set_group_whole_ban") {
         val groupId = fetchOrThrow("group_id") .toLong()
         val enable = fetchOrThrow("enable").toBooleanStrict()
-        call.respondText(SetGroupWholeBan(groupId, enable))
+        call.respondText(SetGroupWholeBan(groupId, enable), ContentType.Application.Json)
     }
 
     getOrPost("/set_group_ban") {
@@ -86,12 +87,12 @@ fun Routing.troopAction() {
         val userId = fetchOrThrow("user_id") .toLong()
         val duration = fetchOrNull("duration")?.toInt() ?: (30 * 60)
 
-        call.respondText(BanTroopMember(groupId, userId, duration))
+        call.respondText(BanTroopMember(groupId, userId, duration), ContentType.Application.Json)
     }
 
     getOrPost("/set_group_kick") {
         val userId = fetchOrThrow("user_id").toLong()
         val groupId = fetchOrThrow("group_id").toLong()
-        call.respondText(KickTroopMember(groupId, userId))
+        call.respondText(KickTroopMember(groupId, userId), ContentType.Application.Json)
     }
 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/MessageAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/MessageAction.kt
@@ -2,6 +2,7 @@ package moe.fuqiuluo.shamrock.remote.api
 
 import moe.fuqiuluo.shamrock.helper.MessageHelper
 import com.tencent.qqnt.kernel.nativeinterface.MsgConstant
+import io.ktor.http.ContentType
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Routing
@@ -26,18 +27,18 @@ fun Routing.messageAction() {
     post("/send_group_forward_msg") {
         val groupId = fetchPostOrNull("group_id")
         val messages = fetchPostJsonArray("messages")
-        call.respondText(SendGroupForwardMsg(messages, groupId ?: ""))
+        call.respondText(SendGroupForwardMsg(messages, groupId ?: ""), ContentType.Application.Json)
     }
 
     post("/send_private_forward_msg") {
         val userId = fetchPostOrNull("user_id")
         val messages = fetchPostJsonArray("messages")
-        call.respondText(SendPrivateForwardMsg(messages, userId ?: ""))
+        call.respondText(SendPrivateForwardMsg(messages, userId ?: ""), ContentType.Application.Json)
     }
 
     getOrPost("/get_forward_msg") {
         val id = fetchOrThrow("id")
-        call.respondText(GetForwardMsg(id))
+        call.respondText(GetForwardMsg(id), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_msg_history") {
@@ -49,7 +50,7 @@ fun Routing.messageAction() {
                 .messageMappingDao()
                 .queryByMsgHashId(it)?.qqMsgId
         } ?: 0L
-        call.respondText(GetHistoryMsg("group", peerId, cnt, startId))
+        call.respondText(GetHistoryMsg("group", peerId, cnt, startId), ContentType.Application.Json)
     }
 
     getOrPost("/get_history_msg") {
@@ -62,23 +63,23 @@ fun Routing.messageAction() {
                 .messageMappingDao()
                 .queryByMsgHashId(it)?.qqMsgId
         } ?: 0L
-        call.respondText(GetHistoryMsg(msgType, peerId, cnt, startId))
+        call.respondText(GetHistoryMsg(msgType, peerId, cnt, startId), ContentType.Application.Json)
     }
 
     getOrPost("/clear_msgs") {
         val msgType = fetchOrThrow("message_type")
         val peerId = fetchOrThrow(if (msgType == "group") "group_id" else "user_id")
-        call.respondText(ClearMsgs(msgType, peerId))
+        call.respondText(ClearMsgs(msgType, peerId), ContentType.Application.Json)
     }
 
     getOrPost("/delete_msg") {
         val msgHash = fetchOrThrow("message_id").toInt()
-        call.respondText(DeleteMessage(msgHash))
+        call.respondText(DeleteMessage(msgHash), ContentType.Application.Json)
     }
 
     getOrPost("/get_msg") {
         val msgHash = fetchOrThrow("message_id").toInt()
-        call.respondText(GetMsg(msgHash))
+        call.respondText(GetMsg(msgHash), ContentType.Application.Json)
     }
 
     route("/(send_msg|send_message)".toRegex()) {
@@ -97,7 +98,7 @@ fun Routing.messageAction() {
                 message = message,
                 autoEscape = autoEscape,
                 fromId = groupId ?: userId ?: ""
-            ))
+            ), ContentType.Application.Json)
         }
         post {
             val msgType = fetchPostOrThrow("message_type")
@@ -123,7 +124,7 @@ fun Routing.messageAction() {
                     autoEscape = autoEscape,
                     fromId = groupId ?: userId ?: ""
                 )
-            })
+            }, ContentType.Application.Json)
         }
     }
 
@@ -149,7 +150,7 @@ fun Routing.messageAction() {
                 SendMessage(MsgConstant.KCHATTYPEGROUP, groupId, fetchPostOrThrow("message"), autoEscape)
             }
 
-            call.respondText(result)
+            call.respondText(result, ContentType.Application.Json)
         }
     }
 
@@ -165,7 +166,7 @@ fun Routing.messageAction() {
                 message = message,
                 autoEscape = autoEscape,
                 fromId = groupId ?: userId
-            ))
+            ), ContentType.Application.Json)
         }
         post {
             val userId = fetchPostOrThrow("user_id")
@@ -196,7 +197,7 @@ fun Routing.messageAction() {
                 )
             }
 
-            call.respondText(result)
+            call.respondText(result, ContentType.Application.Json)
         }
     }
 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/OtherAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/OtherAction.kt
@@ -1,5 +1,6 @@
 package moe.fuqiuluo.shamrock.remote.api
 
+import io.ktor.http.ContentType
 import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
 import io.ktor.http.content.streamProvider
@@ -73,19 +74,19 @@ fun Routing.otherAction() {
     }
 
     getOrPost("/get_version_info") {
-        call.respondText(GetVersionInfo())
+        call.respondText(GetVersionInfo(), ContentType.Application.Json)
     }
 
     getOrPost("/get_device_battery") {
-        call.respondText(GetDeviceBattery())
+        call.respondText(GetDeviceBattery(), ContentType.Application.Json)
     }
 
     getOrPost("/clean_cache") {
-        call.respondText(CleanCache())
+        call.respondText(CleanCache(), ContentType.Application.Json)
     }
 
     getOrPost("/set_restart") {
-        call.respondText(RestartMe(2000))
+        call.respondText(RestartMe(2000), ContentType.Application.Json)
     }
 
     getOrPost("/download_file") {
@@ -94,7 +95,7 @@ fun Routing.otherAction() {
         val name = fetchOrNull("name")
         val threadCnt = fetchOrNull("thread_cnt")?.toInt() ?: 0
         val headers = fetchOrNull("headers") ?: ""
-        call.respondText(DownloadFile(url, b64, threadCnt, headers.split("\r\n"), name))
+        call.respondText(DownloadFile(url, b64, threadCnt, headers.split("\r\n"), name), ContentType.Application.Json)
     }
 
     post("/upload_file") {

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/ProfileAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/ProfileAction.kt
@@ -1,6 +1,7 @@
 package moe.fuqiuluo.shamrock.remote.api
 
 import com.tencent.mobileqq.app.QQAppInterface
+import io.ktor.http.ContentType
 import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
@@ -28,17 +29,21 @@ fun Routing.profileRouter() {
 
         val handler = ActionManager["set_qq_profile"]!!
 
-        call.respondText(handler.handle(
-            ActionSession(mapOf(
-            "nickname" to nickName,
-            "company" to company,
-            "email" to email,
-            "college" to college,
-            "personal_note" to personalNote,
-            "age" to age,
-            "birthday" to birthday
-        ))
-        ))
+        call.respondText(
+            handler.handle(
+                ActionSession(
+                    mapOf(
+                        "nickname" to nickName,
+                        "company" to company,
+                        "email" to email,
+                        "college" to college,
+                        "personal_note" to personalNote,
+                        "age" to age,
+                        "birthday" to birthday
+                    )
+                )
+            ), ContentType.Application.Json
+        )
     }
 
     getOrPost("/get_account_info") {
@@ -48,16 +53,20 @@ fun Routing.profileRouter() {
         val account = accounts?.firstOrNull { it.uin == curUin }
         if (!runtime.isLogin || account == null || !account.isLogined) {
             this.call.respond(
-                CommonResult("ok", Status.InternalHandlerError.code, CurrentAccount(
-                1094950020L, false, "未登录"
-            )
+                CommonResult(
+                    "ok", Status.InternalHandlerError.code, CurrentAccount(
+                        1094950020L, false, "未登录"
+                    )
                 )
             )
         } else {
             this.call.respond(
-                CommonResult("ok", 0, CurrentAccount(
-                curUin.toLong(), runtime.isLogin, if (runtime is QQAppInterface) runtime.currentNickname else "unknown"
-            )
+                CommonResult(
+                    "ok", 0, CurrentAccount(
+                        curUin.toLong(),
+                        runtime.isLogin,
+                        if (runtime is QQAppInterface) runtime.currentNickname else "unknown"
+                    )
                 )
             )
         }
@@ -72,6 +81,6 @@ fun Routing.profileRouter() {
     }
 
     getOrPost("/get_login_info") {
-        call.respondText(GetLoginInfo())
+        call.respondText(GetLoginInfo(), ContentType.Application.Json)
     }
 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/ResourceAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/ResourceAction.kt
@@ -1,5 +1,6 @@
 package moe.fuqiuluo.shamrock.remote.api
 
+import io.ktor.http.ContentType
 import moe.fuqiuluo.shamrock.utils.FileUtils
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -22,68 +23,68 @@ fun Routing.fetchRes() {
     getOrPost("/get_record") {
         val file = formatFileName( fetchGetOrThrow("file") )
         val format = fetchOrThrow("out_format")
-        call.respondText(GetRecord(file, format))
+        call.respondText(GetRecord(file, format), ContentType.Application.Json)
     }
 
     getOrPost("/get_image") {
         val file = formatFileName( fetchGetOrThrow("file") )
-        call.respondText(GetImage(file))
+        call.respondText(GetImage(file), ContentType.Application.Json)
     }
 
     getOrPost("/upload_group_file") {
         val groupId = fetchOrThrow("group_id")
         val file = fetchOrThrow("file")
         val name = fetchOrThrow("name")
-        call.respondText(UploadGroupFile(groupId, file, name))
+        call.respondText(UploadGroupFile(groupId, file, name), ContentType.Application.Json)
     }
 
     getOrPost("/upload_private_file") {
         val userId = fetchOrThrow("user_id")
         val file = fetchOrThrow("file")
         val name = fetchOrThrow("name")
-        call.respondText(UploadPrivateFile(userId, file, name))
+        call.respondText(UploadPrivateFile(userId, file, name), ContentType.Application.Json)
     }
 
     getOrPost("/create_group_file_folder") {
         val groupId = fetchOrThrow("group_id")
         val name = fetchOrThrow("name")
-        call.respondText(CreateGroupFileFolder(groupId, name))
+        call.respondText(CreateGroupFileFolder(groupId, name), ContentType.Application.Json)
     }
 
     getOrPost("/delete_group_folder") {
         val groupId = fetchOrThrow("group_id")
         val id = fetchOrThrow("folder_id")
-        call.respondText(DeleteGroupFolder(groupId, id))
+        call.respondText(DeleteGroupFolder(groupId, id), ContentType.Application.Json)
     }
 
     getOrPost("/delete_group_file") {
         val groupId = fetchOrThrow("group_id")
         val id = fetchOrThrow("file_id")
         val busid = fetchOrThrow("busid").toInt()
-        call.respondText(DeleteGroupFile(groupId, id, busid))
+        call.respondText(DeleteGroupFile(groupId, id, busid), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_file_system_info") {
         val groupId = fetchOrThrow("group_id")
-        call.respondText(GetGroupFileSystemInfo(groupId))
+        call.respondText(GetGroupFileSystemInfo(groupId), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_root_files") {
         val groupId = fetchOrThrow("group_id")
-        call.respondText(GetGroupRootFiles(groupId))
+        call.respondText(GetGroupRootFiles(groupId), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_files_by_folder") {
         val groupId = fetchOrThrow("group_id")
         val folderId = fetchOrThrow("folder_id")
-        call.respondText(GetGroupSubFiles(groupId, folderId))
+        call.respondText(GetGroupSubFiles(groupId, folderId), ContentType.Application.Json)
     }
 
     getOrPost("/get_group_file_url") {
         val groupId = fetchOrThrow("group_id")
         val id = fetchOrThrow("file_id")
         val busid = fetchOrThrow("busid").toInt()
-        call.respondText(GetGroupFileUrl(groupId, id, busid))
+        call.respondText(GetGroupFileUrl(groupId, id, busid), ContentType.Application.Json)
     }
 
     route("/res/[a-fA-F0-9]{32}".toRegex()) {

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/TicketAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/TicketAction.kt
@@ -20,7 +20,7 @@ fun Routing.ticketActions() {
     getOrPost("/get_credentials") {
         val domain = fetchOrNull("domain")
         if (domain != null) {
-            call.respondText(GetCredentials(domain))
+            call.respondText(GetCredentials(domain), ContentType.Application.Json)
         } else {
             call.respondText(GetCredentials(), ContentType.Application.Json)
         }
@@ -29,7 +29,7 @@ fun Routing.ticketActions() {
     getOrPost("/get_cookies") {
         val domain = fetchOrNull("domain")
         if (domain != null) {
-            call.respondText(GetCookies(domain = domain))
+            call.respondText(GetCookies(domain = domain), ContentType.Application.Json)
         } else {
             call.respondText(GetCookies(), ContentType.Application.Json)
         }
@@ -38,7 +38,7 @@ fun Routing.ticketActions() {
     getOrPost("/get_csrf_token") {
         val domain = fetchOrNull("domain")
         if (domain != null) {
-            call.respondText(GetCSRF(domain))
+            call.respondText(GetCSRF(domain), ContentType.Application.Json)
         } else {
             call.respondText(GetCSRF(), ContentType.Application.Json)
         }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/TicketAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/TicketAction.kt
@@ -1,5 +1,6 @@
 package moe.fuqiuluo.shamrock.remote.api
 
+import io.ktor.http.ContentType
 import moe.fuqiuluo.qqinterface.servlet.TicketSvc
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
@@ -13,7 +14,7 @@ fun Routing.ticketActions() {
         val appid =fetchOrThrow("appid")
         val daid = fetchOrThrow("daid")
         val jumpurl = fetchOrThrow("jumpurl")
-        call.respondText(GetHttpCookies(appid, daid, jumpurl))
+        call.respondText(GetHttpCookies(appid, daid, jumpurl), ContentType.Application.Json)
     }
 
     getOrPost("/get_credentials") {
@@ -21,7 +22,7 @@ fun Routing.ticketActions() {
         if (domain != null) {
             call.respondText(GetCredentials(domain))
         } else {
-            call.respondText(GetCredentials())
+            call.respondText(GetCredentials(), ContentType.Application.Json)
         }
     }
 
@@ -30,7 +31,7 @@ fun Routing.ticketActions() {
         if (domain != null) {
             call.respondText(GetCookies(domain = domain))
         } else {
-            call.respondText(GetCookies())
+            call.respondText(GetCookies(), ContentType.Application.Json)
         }
     }
 
@@ -39,7 +40,7 @@ fun Routing.ticketActions() {
         if (domain != null) {
             call.respondText(GetCSRF(domain))
         } else {
-            call.respondText(GetCSRF())
+            call.respondText(GetCSRF(), ContentType.Application.Json)
         }
     }
 

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/UserAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/UserAction.kt
@@ -1,5 +1,6 @@
 package moe.fuqiuluo.shamrock.remote.api
 
+import io.ktor.http.ContentType
 import moe.fuqiuluo.shamrock.helper.LogicException
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
@@ -13,16 +14,16 @@ import moe.fuqiuluo.shamrock.utils.PlatformUtils
 fun Routing.userAction() {
     getOrPost("/set_group_leave") {
         val group = fetchOrThrow("group_id")
-        call.respondText(LeaveTroop(group))
+        call.respondText(LeaveTroop(group), ContentType.Application.Json)
     }
 
     getOrPost("/_get_online_clients") {
-        call.respondText(GetOnlineClients())
+        call.respondText(GetOnlineClients(), ContentType.Application.Json)
     }
 
     getOrPost("/_get_model_show") {
         val model = fetchOrThrow("model")
-        call.respondText(GetModelShowList(model))
+        call.respondText(GetModelShowList(model), ContentType.Application.Json)
     }
 
     getOrPost("/_set_model_show") {
@@ -31,12 +32,12 @@ fun Routing.userAction() {
         val modelshow = fetchOrNull("modelshow") ?: "Android"
         val imei = fetchOrNull("imei") ?: PlatformUtils.getAndroidID()
         val show = fetchOrNull("show")?.toBooleanStrictOrNull() ?: true
-        call.respondText(SetModelShow(model, manu, modelshow, imei, show))
+        call.respondText(SetModelShow(model, manu, modelshow, imei, show), ContentType.Application.Json)
     }
 
     getOrPost("/get_model_show") {
         val uin = fetchOrNull("user_id")
-        call.respondText(GetModelShow(uin?.toLong() ?: 0))
+        call.respondText(GetModelShow(uin?.toLong() ?: 0), ContentType.Application.Json)
     }
 
     getOrPost("/send_like") {
@@ -45,6 +46,6 @@ fun Routing.userAction() {
         call.respondText(SendLike(
             uin.toLong(),
             cnt.toInt()
-        ))
+        ), ContentType.Application.Json)
     }
 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/WeatherAction.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/api/WeatherAction.kt
@@ -1,5 +1,6 @@
 package moe.fuqiuluo.shamrock.remote.api
 
+import io.ktor.http.ContentType
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Routing
@@ -15,11 +16,11 @@ fun Routing.weatherAction() {
             call.respondText(GetWeather(city))
             return@getOrPost
         }
-        call.respondText(GetWeather(cityCode.toInt()))
+        call.respondText(GetWeather(cityCode.toInt()), ContentType.Application.Json)
     }
 
     getOrPost("/get_weather_city_code") {
         val city = fetchOrThrow("city")
-        call.respondText(GetWeatherCityCode(city))
+        call.respondText(GetWeatherCityCode(city), ContentType.Application.Json)
     }
 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/tools/Json.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/tools/Json.kt
@@ -45,14 +45,16 @@ val Collection<Any>.json: JsonArray
     get() {
         val arrayList = arrayListOf<JsonElement>()
         forEach {
-            when (it) {
-                is JsonElement -> arrayList.add(it)
-                is Number -> arrayList.add(it.json)
-                is String -> arrayList.add(it.json)
-                is Boolean -> arrayList.add(it.json)
-                is Map<*, *> -> arrayList.add((it as Map<String, Any>).json)
-                is Collection<*> -> arrayList.add((it as Collection<Any>).json)
-                else -> error("unknown array type: ${it::class.java}")
+            if (it != null) {
+                when (it) {
+                    is JsonElement -> arrayList.add(it)
+                    is Number -> arrayList.add(it.json)
+                    is String -> arrayList.add(it.json)
+                    is Boolean -> arrayList.add(it.json)
+                    is Map<*, *> -> arrayList.add((it as Map<String, Any>).json)
+                    is Collection<*> -> arrayList.add((it as Collection<Any>).json)
+                    else -> error("unknown array type: ${it::class.java}")
+                }
             }
         }
         return arrayList.jsonArray
@@ -62,14 +64,16 @@ val Map<String, Any>.json: JsonObject
     get() {
         val map = hashMapOf<String, JsonElement>()
         forEach { (key, any) ->
-            when (any) {
-                is JsonElement -> map[key] = any
-                is Number -> map[key] = any.json
-                is String -> map[key] = any.json
-                is Boolean -> map[key] = any.json
-                is Map<*, *> -> map[key] = (any as Map<String, Any>).json
-                is Collection<*> -> map[key] = (any as Collection<Any>).json
-                else -> error("unknown object type: ${any::class.java}")
+            if (any != null) {
+                when (any) {
+                    is JsonElement -> map[key] = any
+                    is Number -> map[key] = any.json
+                    is String -> map[key] = any.json
+                    is Boolean -> map[key] = any.json
+                    is Map<*, *> -> map[key] = (any as Map<String, Any>).json
+                    is Collection<*> -> map[key] = (any as Collection<Any>).json
+                    else -> error("unknown object type: ${any::class.java}")
+                }
             }
         }
         return map.jsonObject


### PR DESCRIPTION
1. Add `"application/json"` headers to most of http endpoints (some code were formatted automatically by IDE)
2. Fix a null pointer exception happened during get private chat file type msg. Exception is just like below:
```
ERROR java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:32)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.ktor.server.netty.EventLoopGroupProxy$Companion.create$lambda$1$lambda$0(NettyApplicationEngine.kt:296)
	at io.ktor.server.netty.EventLoopGroupProxy$Companion.$r8$lambda$XgnKz7L6tCWRUaIAa7SVURwtFE4(Unknown Source:0)
	at io.ktor.server.netty.EventLoopGroupProxy$Companion$$ExternalSyntheticLambda1.run(Unknown Source:2)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:1012)
```
btw, file url cannot be got in private chat.