### PR TITLE
允许崩溃后快速重启

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/xposed/actions/InitRemoteService.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/xposed/actions/InitRemoteService.kt
@@ -81,6 +81,7 @@ internal class InitRemoteService : IAction {
                 }
                 require(config.port in 0 .. 65536) { "WebSocketServer端口不合法" }
                 val server = WebSocketService(config.address, config.port!!)
+                server.isReuseAddr = true
                 server.start()
             } catch (e: Throwable) {
                 LogCenter.log(e.stackTraceToString(), Level.ERROR)


### PR DESCRIPTION
app崩溃（或者被系统杀死）后，主动websocket的端口会陷入一段时间的time_wait状态，影响立刻重启。
论坛上已经有相关反馈：https://forum.libfekit.so/d/22-pin-dao-shan-tui/6