### PR TITLE
视频类型消息，md5文件名携带后缀导致hex2bytes失败

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/qqinterface/servlet/msg/convert/MessageElemConverter.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/qqinterface/servlet/msg/convert/MessageElemConverter.kt
@@ -143,13 +143,15 @@ internal sealed class MessageElemConverter: IMessageConvert {
             element: MsgElement
         ): MessageSegment {
             val video = element.videoElement
+            val md5 = video.fileName.split(".")[0]
+
             return MessageSegment(
                 type = "video",
                 data = hashMapOf(
                     "file" to video.fileName,
                     "url" to when(chatType) {
-                        MsgConstant.KCHATTYPEGROUP -> RichProtoSvc.getGroupVideoDownUrl("0", video.fileName, video.fileUuid)
-                        MsgConstant.KCHATTYPEC2C -> RichProtoSvc.getC2CVideoDownUrl("0", video.fileName, video.fileUuid)
+                        MsgConstant.KCHATTYPEGROUP -> RichProtoSvc.getGroupVideoDownUrl("0", md5, video.fileUuid)
+                        MsgConstant.KCHATTYPEC2C -> RichProtoSvc.getC2CVideoDownUrl("0", md5, video.fileUuid)
                         else -> unknownChatType(chatType)
                     }
                 ).also {


### PR DESCRIPTION
video.fileName = 4f3a10d9ec68cf8ececf2c649a9ebe49.mp4
导致
md5Hex.hex2ByteArray()
异常