### PR TITLE
go-cqhttp like card and nickname field

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/api/GlobalEventTransmitter.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/api/GlobalEventTransmitter.kt
@@ -85,7 +85,7 @@ internal object GlobalEventTransmitter: BaseSvc() {
                             .ifBlank { record.sendRemarkName }
                             .ifBlank { record.sendMemberName }
                             .ifBlank { record.peerName },
-                        card = record.sendMemberName.ifBlank { record.sendNickName },
+                        card = record.sendMemberName,
                         role = when (record.senderUin) {
                             GroupSvc.getOwner(record.peerUin.toString()) -> MemberRole.Owner
                             in GroupSvc.getAdminList(record.peerUin.toString()) -> MemberRole.Admin


### PR DESCRIPTION
无群名片时：`nickname`为昵称、`card`为空
有群名片时：`nickname`为昵称、`card`为群名片

没环境编译，不能保证结果
但是看了一会有点怀疑是QQ在发送者有群名片的情况下`MsgRecord.sendNickName`字段提供的也是群名片
所以最后的结果可能是

无群名片时：`nickname`为昵称、`card`为空
有群名片时：`nickname`为群名片、`card`为群名片
