### PR TITLE
支持全员禁言通知事件

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/proto/ProtoMap.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/proto/ProtoMap.kt
@@ -61,7 +61,7 @@ class ProtoMap(
         var curMap = value
         tags.forEachIndexed { index, tag ->
             if (index == tags.size - 1) {
-                return curMap[tag] ?: error("Tag $tag not found")
+                return curMap[tag] ?: error("pb[${tags.joinToString(", ")}][$index] Tag $tag not found")
             }
             curMap[tag]?.let { v ->
                 if (v is ProtoMap) {
@@ -69,7 +69,7 @@ class ProtoMap(
                 } else {
                     return v
                 }
-            } ?: error("Tag $tag not found")
+            } ?: error("pb[${tags.joinToString(", ")}][$index] Tag $tag not found")
         }
         error("Instance is not ProtoMap for get(${tags.first()})")
     }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/api/GlobalEventTransmitter.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/api/GlobalEventTransmitter.kt
@@ -305,6 +305,7 @@ internal object GlobalEventTransmitter: BaseSvc() {
 
         suspend fun transGroupBan(
             msgTime: Long,
+            subType: NoticeSubType,
             operation: Long,
             target: Long,
             groupCode: Long,
@@ -315,7 +316,7 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 selfId = app.longAccountUin,
                 postType = PostType.Notice,
                 type = NoticeType.GroupBan,
-                subType = if (duration == 0) NoticeSubType.LiftBan else NoticeSubType.Ban,
+                subType = subType,
                 operatorId = operation,
                 userId = target,
                 senderId = operation,


### PR DESCRIPTION
参考文档：https://docs.go-cqhttp.org/event/#%E7%BE%A4%E7%A6%81%E8%A8%80 (群禁言)

将 target(user_id) 设为 `0`，将 duration 设为 `-1` 即为全员禁言。

全员禁言和普通禁言相比，全员禁言少了 `pb[1, 3, 2, 5, 3, 1]`，在支持全员禁言之前，只要收到全员禁言就会报错
```
WARN onMsgPush(msgType: 732, subType: 12): java.lang.IllegalStateException: Tag 1 not found
```