### PR TITLE
修复群头衔更改通知报错

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/qqinterface/servlet/msg/convert/MessageElemConverter.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/qqinterface/servlet/msg/convert/MessageElemConverter.kt
@@ -324,7 +324,8 @@ internal sealed class MessageElemConverter: IMessageConvert {
                     val notify = tip.jsonGrayTipElement
                     when(notify.busiId) {
                         /* 新人入群 */ 17L, /* 群戳一戳 */1061L,
-                        /* 群撤回 */1014L, /* 群设精消息 */2401L -> {}
+                        /* 群撤回 */1014L, /* 群设精消息 */2401L,
+                        /* 群头衔 */2407L -> {}
                         else -> LogCenter.log("不支持的灰条类型(JSON): ${notify.busiId}", Level.WARN)
                     }
                 }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/listener/PrimitiveListener.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/listener/PrimitiveListener.kt
@@ -12,15 +12,7 @@ import kotlinx.io.core.discardExact
 import kotlinx.io.core.readBytes
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-import moe.fuqiuluo.proto.ProtoByteString
-import moe.fuqiuluo.proto.ProtoMap
-import moe.fuqiuluo.proto.asInt
-import moe.fuqiuluo.proto.asLong
-import moe.fuqiuluo.proto.asUtf8String
-import moe.fuqiuluo.proto.ProtoUtils
-import moe.fuqiuluo.proto.asByteArray
-import moe.fuqiuluo.proto.asList
-import moe.fuqiuluo.proto.asULong
+import moe.fuqiuluo.proto.*
 import moe.fuqiuluo.qqinterface.servlet.FriendSvc.requestFriendSystemMsgNew
 import moe.fuqiuluo.qqinterface.servlet.GroupSvc.requestGroupSystemMsgNew
 import moe.fuqiuluo.qqinterface.servlet.TicketSvc.getLongUin
@@ -211,9 +203,12 @@ internal object PrimitiveListener {
                 LogCenter.log("onGroupTitleChange error: ${e.stackTraceToString()}", Level.WARN)
             }
         }
+        var detail5 = detail[5]
+        if (detail5 is ProtoList) {
+            detail5 = detail5.value.first { it is ProtoMap }
+        }
 
-        val targetUin = detail[5, 5].asLong
-
+        val targetUin = detail5[5].asLong
         var groupId:Long
         try {
             groupId = detail[4].asULong
@@ -222,7 +217,7 @@ internal object PrimitiveListener {
         }
 
         // 恭喜<{\"cmd\":5,\"data\":\"qq\",\"text}\":\"nickname\"}>获得群主授予的<{\"cmd\":1,\"data\":\"https://qun.qq.com/qqweb/m/qun/medal/detail.html?_wv=16777223&bid=2504&gc=gid&isnew=1&medal=302&uin=uin\",\"text\":\"title\",\"url\":\"https://qun.qq.com/qqweb/m/qun/medal/detail.html?_wv=16777223&bid=2504&gc=gid&isnew=1&medal=302&uin=uin\"}>头衔
-        val titleChangeInfo = detail[5, 2].asUtf8String
+        val titleChangeInfo = detail5[2].asUtf8String
         if (titleChangeInfo.indexOf("群主授予") == -1) {
             return
         }


### PR DESCRIPTION
QQ版本：8.9.80.12440

报错如下，原因是 `[1, 3, 2, 5]` 为 ProtoList 而非 ProtoMap，导致在获取 targetUin，asLong 时出现未预料的错误
```
WARN onMsgPush(msgType: 732, subType: 16): java.lang.ClassCastException: moe.fuqiuluo.proto.ProtoList cannot be cast to moe.fuqiuluo.proto.ProtoNumber
```

<details>
  <summary><code>pb.toJson()</code></summary>

```json5
{
    "1": {
        "1": {
            // ...
        },
        "2": {
            // ...
        },
        "3": {
            "1": {},
            "2": {
                "13": 6,
                "4": 1919810, // groupId
                "5": [
                    74439140803724111,
                    {
                        "2": "xxxxxxxxxxxxxxxxxxx", // titleChangeInfo
                        "3": 1,
                        "5": 114514// targetUin
                    }
                ]
            }
        }
    }
}
```
</details>