### PR TITLE
[WIP] fix: should encode defaults in websocket json

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/tools/Json.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/tools/Json.kt
@@ -22,7 +22,7 @@ val GlobalJson = Json {
     ignoreUnknownKeys = true // 忽略未知key
     isLenient = true // 宽松模式
     allowSpecialFloatingPointValues = true // 允许特殊浮点数值（如NaN）
-    encodeDefaults = false // 不编码默认值
+    encodeDefaults = true // 编码默认值
     prettyPrint = false // 格式化输出
     coerceInputValues = true // 强制输入值
 }


### PR DESCRIPTION
**请勿合并！目前发现此 PR 会导致发送图片后 bot 断开与 nonebot2 的连接，原因待查**

```kotlin
val GlobalJson = Json {
    ignoreUnknownKeys = true // 忽略未知key
    isLenient = true // 宽松模式
    allowSpecialFloatingPointValues = true // 允许特殊浮点数值（如NaN）
    encodeDefaults = false // 不编码默认值
    prettyPrint = false // 格式化输出
    coerceInputValues = true // 强制输入值
}
```

此设置中的 `encodeDefaults = false` 使得 0、空字符串不会被编码到 json 字符串中，导致配合 [adapter-onebot](https://github.com/nonebot/adapter-onebot) 使用时出现一些错误

例如：
+ 在获取不到 uin 时将 user_id 字段值定义为 0，导致编码为 json 时 user_id 缺失：https://github.com/whitechi73/OpenShamrock/issues/150#issuecomment-1901727933

+ 申请加群时，如验证消息为空，则 `comment` 字段不会被编码到 json 中，不符合 onebot 标准，配合 [adapter-onebot](https://github.com/nonebot/adapter-onebot) 使用时出错

*由于我对 OpenShamrock 了解不深，暂时不知更改此设置是否会导致某些副作用*