### PR TITLE
notice类消息，新增source，解决poke等特殊消息没有办法直接判断消息来源的问题。修改后通过notice类消息的source字段…

### DIFF
--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/api/GlobalEventTransmitter.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/api/GlobalEventTransmitter.kt
@@ -21,6 +21,7 @@ import moe.fuqiuluo.shamrock.remote.service.data.push.MsgSubType
 import moe.fuqiuluo.shamrock.remote.service.data.push.MsgType
 import moe.fuqiuluo.shamrock.remote.service.data.push.PostType
 import moe.fuqiuluo.shamrock.remote.service.data.push.MessageEvent
+import moe.fuqiuluo.shamrock.remote.service.data.push.MessageSource
 import moe.fuqiuluo.shamrock.remote.service.data.push.MessageTempSource
 import moe.fuqiuluo.shamrock.remote.service.data.push.NoticeEvent
 import moe.fuqiuluo.shamrock.remote.service.data.push.NoticeSubType
@@ -235,7 +236,8 @@ internal object GlobalEventTransmitter: BaseSvc() {
                     url = url,
                     subId = fileSubId,
                     expire = expireTime
-                )
+                ),
+                messageSource =MessageSource.Private
             ))
             return true
         }
@@ -258,16 +260,17 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 selfId = app.longAccountUin,
                 postType = PostType.Notice,
                 type = NoticeType.GroupUpload,
+                groupId = groupId,
                 operatorId = userId,
                 userId = userId,
-                groupId = groupId,
                 file = GroupFileMsg(
                     id = uuid,
                     name = fileName,
                     size = fileSize,
                     busid = bizId.toLong(),
                     url = url
-                )
+                ),
+                messageSource =MessageSource.Private
             ))
             return true
         }
@@ -284,13 +287,14 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 postType = PostType.Notice,
                 type = NoticeType.Notify,
                 subType = NoticeSubType.Sign,
-                userId = target,
                 groupId = groupCode,
+                userId = target,
                 target = target,
                 signDetail = SignDetail(
                     rankImg = rankImg,
                     action = action
-                )
+                ),
+                messageSource =MessageSource.Group
             ))
             return true
         }
@@ -306,6 +310,7 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 userId = operation,
                 groupId = groupCode,
                 target = target,
+                messageSource =MessageSource.Group,
                 pokeDetail = PokeDetail(
                     action = action,
                     suffix = suffix,
@@ -331,14 +336,15 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 postType = PostType.Notice,
                 type = noticeType,
                 subType = noticeSubType,
+                groupId = groupCode,
                 operatorId = operator,
+                operatorUid = operatorUid,
                 userId = target,
+                userUid = targetUid,
                 senderId = operator,
                 target = target,
-                groupId = groupCode,
                 targetUid = targetUid,
-                operatorUid = operatorUid,
-                userUid = targetUid
+                messageSource =MessageSource.Group,
             ))
             return true
         }
@@ -356,12 +362,13 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 postType = PostType.Notice,
                 type = NoticeType.GroupAdminChange,
                 subType = if (setAdmin) NoticeSubType.Set else NoticeSubType.UnSet,
+                groupId = groupCode,
                 operatorId = 0,
                 userId = target,
                 userUid = targetUid,
                 target = target,
                 targetUid = targetUid,
-                groupId = groupCode
+                messageSource =MessageSource.Group,
             ))
             return true
         }
@@ -382,14 +389,15 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 postType = PostType.Notice,
                 type = NoticeType.GroupBan,
                 subType = subType,
+                groupId = groupCode,
                 operatorId = operator,
+                operatorUid = operatorUid,
                 userId = target,
                 senderId = operator,
-                target = target,
-                groupId = groupCode,
                 duration = duration,
-                operatorUid = operatorUid,
-                targetUid = targetUid
+                target = target,
+                targetUid = targetUid,
+                messageSource =MessageSource.Group,
             ))
             return true
         }
@@ -407,11 +415,12 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 selfId = app.longAccountUin,
                 postType = PostType.Notice,
                 type = NoticeType.GroupRecall,
+                groupId = groupCode,
                 operatorId = operator,
                 userId = target,
                 msgId = msgHash,
                 tip = tipText,
-                groupId = groupCode
+                messageSource =MessageSource.Group,
             ))
             return true
         }
@@ -428,10 +437,11 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 selfId = app.longAccountUin,
                 postType = PostType.Notice,
                 type = NoticeType.GroupCard,
+                groupId = groupId,
                 userId = targetId,
                 cardNew = newCard,
                 cardOld = oldCard,
-                groupId = groupId
+                messageSource =MessageSource.Group,
             ))
             return true
         }
@@ -447,10 +457,11 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 selfId = app.longAccountUin,
                 postType = PostType.Notice,
                 type = NoticeType.Notify,
-                userId = targetId,
+                subType = NoticeSubType.Title,
                 groupId = groupId,
+                userId = targetId,
                 title = title,
-                subType = NoticeSubType.Title
+                messageSource =MessageSource.Group,
             ))
             return true
         }
@@ -468,11 +479,12 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 selfId = app.longAccountUin,
                 postType = PostType.Notice,
                 type = NoticeType.Essence,
-                senderId = senderUin,
+                subType = subType,
                 groupId = groupId,
                 operatorId = operatorUin,
+                senderId = senderUin,
                 msgId = msgId,
-                subType = subType
+                messageSource =MessageSource.Group,
             ))
             return true
         }
@@ -497,7 +509,8 @@ internal object GlobalEventTransmitter: BaseSvc() {
                     actionImg = actionImg,
                     action = action,
                     suffix = suffix
-                )
+                ),
+                messageSource =MessageSource.Private
             ))
             return true
         }
@@ -511,7 +524,8 @@ internal object GlobalEventTransmitter: BaseSvc() {
                 operatorId = operation,
                 userId = operation,
                 msgId = msgHashId,
-                tip = tipText
+                tip = tipText,
+                messageSource =MessageSource.Private,
             ))
             return true
         }

--- a/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/data/push/NoticeEvent.kt
+++ b/xposed/src/main/java/moe/fuqiuluo/shamrock/remote/service/data/push/NoticeEvent.kt
@@ -27,27 +27,20 @@ internal enum class RequestType {
 @Serializable
 internal enum class NoticeSubType {
     @SerialName("none") None,
-
     @SerialName("ban") Ban,
     @SerialName("lift_ban") LiftBan,
-
     @SerialName("set") Set,
     @SerialName("unset") UnSet,
-
     @SerialName("add") Add,
     @SerialName("invite") Invite,
     @SerialName("approve") Approve,
     @SerialName("leave") Leave,
     @SerialName("kick") Kick,
     @SerialName("kick_me") KickMe,
-
     @SerialName("poke") Poke,
     @SerialName("sign") Sign,
-
-
     @SerialName("title") Title,
     @SerialName("delete") Delete,
-
 }
 
 @Serializable
@@ -55,6 +48,13 @@ internal enum class RequestSubType {
     @SerialName("none") None,
     @SerialName("add") Add,
     @SerialName("invite") Invite,
+}
+
+@Serializable
+internal enum class MessageSource {
+    @SerialName("group") Group,
+
+    @SerialName("private") Private,
 }
 
 /**
@@ -97,6 +97,7 @@ internal data class NoticeEvent(
 
     // 群打卡
     @SerialName("sign_detail") val signDetail: SignDetail? = null,
+    @SerialName("source") val messageSource: MessageSource? = null,
 
     )
 
@@ -138,7 +139,7 @@ internal data class PrivateFileMsg(
 )
 
 @Serializable
-internal data class PokeDetail (
+internal data class PokeDetail(
     val action: String? = "戳了戳",
     val suffix: String? = "",
     @SerialName("action_img_url")
@@ -146,7 +147,7 @@ internal data class PokeDetail (
 )
 
 @Serializable
-internal data class SignDetail (
+internal data class SignDetail(
     val action: String? = "今日第1个打卡",
     @SerialName("rank_img")
     val rankImg: String? = "",


### PR DESCRIPTION
因为目前的notice类消息没有消息的来源，例如poke，在ws中走的是notice通道而不是message通道，这样就使私聊消息和群聊消息几乎一致，从而需要判断json-key中是否存在group_id来判断消息来源是来自群还是私聊，这样对于部分语言接入就很不友好

新增字段后，在判断source之后即可使用对应的struct一次性扫进去